### PR TITLE
Fix FSM message handlers for riddles and word game

### DIFF
--- a/handlers/word_game.py
+++ b/handlers/word_game.py
@@ -1,5 +1,8 @@
 from aiogram import Router, F
 from aiogram.types import Message, CallbackQuery
+from aiogram.filters import StateFilter
+from aiogram.fsm.context import FSMContext
+from aiogram.fsm.state import State, StatesGroup
 from keyboards import word_game_menu, back_button
 from data import user_data
 from questions import question_bank
@@ -9,8 +12,10 @@ import random
 router = Router()
 logger = logging.getLogger(__name__)
 
-# Временное хранение текущих слов для пользователей
-user_words = {}
+
+class WordState(StatesGroup):
+    """Состояния для игры 'Угадай слово'."""
+    guessing = State()
 
 
 def create_word_mask(word: str, guessed: set[str] = None) -> str:
@@ -38,7 +43,7 @@ async def word_menu_callback(callback: CallbackQuery):
 
 
 @router.callback_query(F.data.startswith("word:"))
-async def word_handler(callback: CallbackQuery):
+async def word_handler(callback: CallbackQuery, state: FSMContext):
     """Обработчик старта игры в слова"""
     word_type = callback.data.split(":")[1]
     user_id = callback.from_user.id
@@ -54,14 +59,17 @@ async def word_handler(callback: CallbackQuery):
     masked = create_word_mask(word)
     points = get_word_points(difficulty)
 
-    user_words[user_id] = {
-        "word": word,
-        "masked": masked,
-        "guessed_letters": set(),
-        "attempts": 6,
-        "difficulty": difficulty,
-        "points": points
-    }
+    await state.set_state(WordState.guessing)
+    await state.update_data(
+        game={
+            "word": word,
+            "masked": masked,
+            "guessed_letters": set(),
+            "attempts": 6,
+            "difficulty": difficulty,
+            "points": points,
+        }
+    )
 
     text = (
         f"🔤 <b>Угадай слово</b>\n\n"
@@ -77,69 +85,77 @@ async def word_handler(callback: CallbackQuery):
     await callback.answer()
 
 
-@router.message(F.text)
-async def handle_word_guess(message: Message):
+@router.message(StateFilter(WordState.guessing), F.text)
+async def handle_word_guess(message: Message, state: FSMContext):
     """Обработчик угадывания слов"""
     user_id = message.from_user.id
     guess = message.text.strip().lower()
 
-    # Проверяем, есть ли активная игра
-    if user_id not in user_words:
-        return  # Нет активной игры
+    try:
+        data = await state.get_data()
+        game = data.get("game")
+        if not game:
+            await state.clear()
+            return
 
-    game = user_words[user_id]
-    word = game["word"]
-    guessed = game["guessed_letters"]
-    attempts = game["attempts"]
-    points = game["points"]
+        word = game["word"]
+        guessed = game["guessed_letters"]
+        attempts = game["attempts"]
+        points = game["points"]
 
-    response = ""
+        response = ""
 
-    # Полное слово
-    if len(guess) > 1:
-        if guess == word:
-            response = f"🎉 Поздравляю! Ты угадал слово <b>{word}</b> и заработал <b>{points}</b> очков."
-            user_data.add_points(user_id, points)
-            del user_words[user_id]
+        # Полное слово
+        if len(guess) > 1:
+            if guess == word:
+                response = f"🎉 Поздравляю! Ты угадал слово <b>{word}</b> и заработал <b>{points}</b> очков."
+                await user_data.update_score(user_id, points)
+                await user_data.update_stat(user_id, "words_guessed", 1)
+                await state.clear()
+            else:
+                game["attempts"] -= 1
+                if game["attempts"] <= 0:
+                    response = f"💥 Ты исчерпал все попытки. Правильное слово: <b>{word}</b>."
+                    await state.clear()
+                else:
+                    response = (
+                        f"❌ Неверно. Осталось попыток: <b>{game['attempts']}</b>\n"
+                        f"Слово: {game['masked']}"
+                    )
+
+        # Буква
         else:
-            game["attempts"] -= 1
-            if game["attempts"] <= 0:
-                response = f"💥 Ты исчерпал все попытки. Правильное слово: <b>{word}</b>."
-                del user_words[user_id]
+            letter = guess
+            if letter in guessed:
+                response = f"⚠️ Буква <b>{letter}</b> уже была. Попробуй другую."
+            elif letter in word:
+                guessed.add(letter)
+                new_mask = create_word_mask(word, guessed)
+                game["masked"] = new_mask
+                if "_" not in new_mask:
+                    response = f"🎉 Отлично! Ты открыл все буквы: <b>{word}</b>. Получено <b>{points}</b> очков."
+                    await user_data.update_score(user_id, points)
+                    await user_data.update_stat(user_id, "words_guessed", 1)
+                    await state.clear()
+                else:
+                    response = (
+                        f"✅ Есть такая буква!\n"
+                        f"Слово: {new_mask}\n"
+                        f"Попыток осталось: <b>{attempts}</b>"
+                    )
             else:
-                response = (
-                    f"❌ Неверно. Осталось попыток: <b>{game['attempts']}</b>\n"
-                    f"Слово: {game['masked']}"
-                )
+                game["attempts"] -= 1
+                if game["attempts"] <= 0:
+                    response = f"💥 Ты исчерпал все попытки. Правильное слово: <b>{word}</b>."
+                    await state.clear()
+                else:
+                    response = (
+                        f"❌ Буквы <b>{letter}</b> нет. Осталось попыток: <b>{game['attempts']}</b>\n"
+                        f"Слово: {game['masked']}"
+                    )
 
-    # Буква
-    else:
-        letter = guess
-        if letter in guessed:
-            response = f"⚠️ Буква <b>{letter}</b> уже была. Попробуй другую."
-        elif letter in word:
-            guessed.add(letter)
-            new_mask = create_word_mask(word, guessed)
-            game["masked"] = new_mask
-            if "_" not in new_mask:
-                response = f"🎉 Отлично! Ты открыл все буквы: <b>{word}</b>. Получено <b>{points}</b> очков."
-                user_data.add_points(user_id, points)
-                del user_words[user_id]
-            else:
-                response = (
-                    f"✅ Есть такая буква!\n"
-                    f"Слово: {new_mask}\n"
-                    f"Попыток осталось: <b>{attempts}</b>"
-                )
-        else:
-            game["attempts"] -= 1
-            if game["attempts"] <= 0:
-                response = f"💥 Ты исчерпал все попытки. Правильное слово: <b>{word}</b>."
-                del user_words[user_id]
-            else:
-                response = (
-                    f"❌ Буквы <b>{letter}</b> нет. Осталось попыток: <b>{game['attempts']}</b>\n"
-                    f"Слово: {game['masked']}"
-                )
-
-    await message.answer(response, reply_markup=back_button("word"))
+        await message.answer(response, reply_markup=back_button("word"))
+    except Exception as e:
+        logger.error(f"Ошибка в игре слова: {e}")
+        await state.clear()
+        await message.answer("❌ Произошла ошибка в игре.", reply_markup=back_button("word"))


### PR DESCRIPTION
## Summary
- wire FSM state for riddle and word guessing games
- handle state errors gracefully
- ensure state is set on game start and cleared afterwards

## Testing
- `python -m py_compile handlers/riddles.py handlers/word_game.py`

------
https://chatgpt.com/codex/tasks/task_e_6851b648592083278a5abc1ec50f302c